### PR TITLE
Bump arrow 57→58 + object_store 0.12→0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ members = [
 ]
 
 [patch.crates-io]
-arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }        # spiceai-56
-arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }  # spiceai-56
-arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" } # spiceai-56
-arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }   # spiceai-56
-arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }   # spiceai-56
-arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }    # spiceai-56
-arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" }    # spiceai-56
-arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "9f9c372ff5744488226462e3ea7d94ff47909833" } # spiceai-56
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }        # spiceai-56
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }  # spiceai-56
+arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # spiceai-56
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # spiceai-56
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # spiceai-56
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # spiceai-56
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # spiceai-56
+arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # spiceai-56

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ members = [
 ]
 
 [patch.crates-io]
-arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }        # spiceai-56
-arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }  # spiceai-56
-arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # spiceai-56
-arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # spiceai-56
-arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # spiceai-56
-arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # spiceai-56
-arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # spiceai-56
-arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # spiceai-56
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }        # arrow 58.3.0
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }  # arrow 58.3.0
+arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # arrow 58.3.0
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # arrow 58.3.0
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }   # arrow 58.3.0
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # arrow 58.3.0
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" }    # arrow 58.3.0
+arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "70b568f01bbe2546f2e97bbdbae1fdf08b57d74a" } # arrow 58.3.0

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -19,9 +19,9 @@ default = ["cert-auth"]
 polars = ["dep:polars-core", "dep:polars-io"]
 
 [dependencies]
-arrow-array = "57"
-arrow-ipc = "57"
-arrow-schema = "57"
+arrow-array = "58"
+arrow-ipc = "58"
+arrow-schema = "58"
 async-trait = "0.1"
 async-stream = "0.3.5"
 base64 = "0.22"
@@ -52,12 +52,12 @@ polars-io = { version = ">=0.41", features = [
 
 # put request support
 glob = { version = "0.3" }
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 anyhow = "1"
-arrow = { version = "57", features = ["prettyprint"] }
+arrow = { version = "58", features = ["prettyprint"] }
 clap = { version = "4", features = ["derive"] }
 pretty_env_logger = "0.5"
 tokio = { version = "1.35", features = ["macros", "rt-multi-thread"] }

--- a/snowflake-api/examples/tracing/Cargo.toml
+++ b/snowflake-api/examples/tracing/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-arrow = { version = "56", features = ["prettyprint"] }
+arrow = { version = "58", features = ["prettyprint"] }
 dotenv = "0.15"
 snowflake-api = { path = "../../../snowflake-api" }
 

--- a/snowflake-api/src/put.rs
+++ b/snowflake-api/src/put.rs
@@ -7,7 +7,7 @@ use futures::TryStreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::limit::LimitStore;
 use object_store::local::LocalFileSystem;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::task;
 
 use crate::responses::{AwsPutGetStageInfo, PutGetExecResponse, PutGetStageInfo};

--- a/snowflake-api/src/put.rs
+++ b/snowflake-api/src/put.rs
@@ -7,7 +7,7 @@ use futures::TryStreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::limit::LimitStore;
 use object_store::local::LocalFileSystem;
-use object_store::{ObjectStore, ObjectStoreExt};
+use object_store::ObjectStore;
 use tokio::task;
 
 use crate::responses::{AwsPutGetStageInfo, PutGetExecResponse, PutGetStageInfo};


### PR DESCRIPTION
Bumps arrow from 57 to 58 and object_store from 0.12 to 0.13 in the Spice snowflake-rs fork, keeping it aligned with the Arrow 58 workspace.

Targets the canonical `spiceai-58` version branch.

Part of the spiceai/spiceai DataFusion 53.1 / Arrow 58.3 upgrade (spiceai/spiceai#11118).