### PR TITLE
fix(put): import ObjectStoreExt for get/put (object_store 0.13)

### DIFF
--- a/snowflake-api/src/put.rs
+++ b/snowflake-api/src/put.rs
@@ -8,6 +8,7 @@ use object_store::aws::AmazonS3Builder;
 use object_store::limit::LimitStore;
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use tokio::task;
 
 use crate::responses::{AwsPutGetStageInfo, PutGetExecResponse, PutGetStageInfo};


### PR DESCRIPTION
object_store 0.13 moved the `get`/`put` convenience methods from the `ObjectStore` trait to a new `ObjectStoreExt` extension trait. `snowflake-api/src/put.rs` calls `LocalFileSystem::get` and `store.put` without importing `ObjectStoreExt`, so the spiceai-58 port (arrow 58 + object_store 0.13, merged in #8) fails to compile:

```
error[E0599]: no method named `get` found for struct `LocalFileSystem`
error[E0599]: no method named `put` found for reference `&T`
```

Adds `use object_store::ObjectStoreExt;`. Verified: `cargo check -p snowflake-api` is clean against object_store 0.13.2. Unblocks spiceai PR #11118.