### PR TITLE
Bump reqwest to 0.13

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -29,13 +29,13 @@ bytes = "1"
 futures = "0.3"
 log = "0.4"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "gzip",
     "json",
-    "rustls-tls",
+    "rustls",
 ] }
-reqwest-middleware = { version = "0.4", features = ["json"] }
-reqwest-retry = "0.7"
+reqwest-middleware = { version = "0.5", features = ["json"] }
+reqwest-retry = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snowflake-jwt = { version = "0.3", optional = true }
@@ -52,7 +52,7 @@ polars-io = { version = ">=0.41", features = [
 
 # put request support
 glob = { version = "0.3" }
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.14", features = ["aws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]

--- a/snowflake-api/examples/tracing/Cargo.toml
+++ b/snowflake-api/examples/tracing/Cargo.toml
@@ -13,8 +13,8 @@ opentelemetry = "0.27"
 opentelemetry-otlp = "0.27"
 opentelemetry-semantic-conventions = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-reqwest-middleware = "0.4"
-reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_21"] }
+reqwest-middleware = "0.5"
+reqwest-tracing = { version = "0.6", features = ["opentelemetry_0_27"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.28"

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -71,7 +71,7 @@ impl QueryType {
                 method: reqwest::Method::POST,
             },
             Self::ArrowQueryResult(query_result_url) => QueryContext {
-                path: query_result_url.to_string(),
+                path: query_result_url.clone(),
                 accept_mime: "application/snowflake",
                 method: reqwest::Method::GET,
             },

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -632,7 +632,7 @@ impl SnowflakeApi {
             let resp = self
                 .connection
                 .request::<ExecResponse>(
-                    QueryType::ArrowQueryResult(query_result_url.to_string()),
+                    QueryType::ArrowQueryResult(query_result_url.clone()),
                     &self.account_identifier,
                     &[],
                     Some(&parts.session_token_auth_header),

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -300,7 +300,7 @@ impl Session {
         Ok(PasswordLoginRequest {
             data: PasswordRequestData {
                 login_request_common: self.login_request_common(),
-                password: password.to_string(),
+                password: password.clone(),
             },
         })
     }


### PR DESCRIPTION
Bumps the HTTP/storage stack to the reqwest 0.13 line. No behavioral changes.

- `reqwest` 0.12 → 0.13 (`rustls-tls` feature → `rustls`, reqwest 0.13's rename)
- `reqwest-middleware` 0.4 → 0.5, `reqwest-retry` 0.7 → 0.9 (first releases on reqwest 0.13)
- `object_store` 0.13 → 0.14 (first release on reqwest 0.13; the stage PUT/GET code compiles unchanged)
- Fix 3 pre-existing `clippy::implicit_clone` lints (`String::to_string` → `clone`) that CI's `clippy -- -D warnings` flags under current stable

Validated locally on reqwest 0.13.4 + object_store 0.14.0: build, `clippy --all-targets -- -D warnings`, `cargo fmt --check`, and test compilation all clean.

Part of moving the Spice.ai runtime workspace onto reqwest 0.13 for the OpenTelemetry 0.32 upgrade.